### PR TITLE
Remove ?author=x page to avoid promoting CMS usernames and remove Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-/vendor
+# Composer
+vendor/
+lib/vendor/
+
+# Lock files
+composer.lock
+!lib/composer.lock
+
+# Local files
 .idea
 .DS_Store
-composer.lock

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Register the autoloader for the plugin's plugin classes.
+ *
+ * Based off the official PSR-4 autoloader example found here:
+ * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md
+ *
+ * @param string $class The fully-qualified class name
+ *
+ * @return void
+ */
+
+spl_autoload_register(
+	function ( $class ) {
+		$namspaces = [
+			'Eighteen73\\Orbit\\'         => __DIR__ . '/includes/classes/',
+			'Eighteen73\\Orbit\\Vendor\\' => __DIR__ . '/lib/packages/',
+		];
+		foreach ( $namspaces as $prefix => $base_dir ) {
+			$len = strlen( $prefix );
+			if ( 0 !== strncmp( $prefix, $class, $len ) ) {
+				return;
+			}
+			$relative_class = substr( $class, $len );
+			$file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+			if ( file_exists( $file ) ) {
+				require $file;
+			}
+		}
+	}
+);

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=7.4",
-    "eighteen73/settings-api": "^1.1.1"
+    "php": ">=7.4"
   },
   "require-dev": {
     "eighteen73/phpcs-composer": "^1.0.0"

--- a/includes/classes/Forms/Options.php
+++ b/includes/classes/Forms/Options.php
@@ -8,7 +8,7 @@
 namespace Eighteen73\Orbit\Forms;
 
 use Eighteen73\Orbit\Singleton;
-use Eighteen73\SettingsApi\SettingsApi;
+use Eighteen73\Orbit\Vendor\Eighteen73\SettingsApi\SettingsApi;
 
 /**
  * The options form for this plugin

--- a/includes/classes/Security/HideAuthor.php
+++ b/includes/classes/Security/HideAuthor.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Remove ?author=x page to avoid promoting CMS usernames
+ *
+ * @package Orbit
+ */
+
+namespace Eighteen73\Orbit\Security;
+
+use Eighteen73\Orbit\Singleton;
+
+/**
+ * Remove ?author=x page to avoid promoting CMS usernames
+ */
+class HideAuthor {
+	use Singleton;
+
+	/**
+	 * Run on init
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		add_action( 'template_redirect', [ $this, 'author_page_404' ] );
+	}
+
+	/**
+	 * Remove ?author=x page to avoid promoting CMS usernames
+	 *
+	 * @return string
+	 */
+	public function author_page_404() {
+		global $wp_query;
+
+		if ( is_author() ) {
+			$wp_query->set_404();
+			status_header( 404 );
+		}
+	}
+}

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,18 @@
+# Lib Directory
+
+**You do not need run a Composer to use this plugin.**
+
+This directory allows the plugin to be distributed with other packages included, but without the requirement 
+for end users to use Composer. 
+
+Note that each included package is prefixed with the namespace `Eighteen73\Orbit\Vendor` to avoid conflicts with other plugins/packages. 
+
+## Adding Packages
+
+1. Add you package in this directory using `composer require package/name --dev`
+2. List your package in composer.json under "extra > mozart > packages"
+3. Run `composer install` to trigger the post-install script
+
+## Updating Packages
+
+Run `composer update` within this directory.

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "eighteen73/orbit-lib",
+    "description": "Orbit dependencies",
+    "minimum-stability": "stable",
+    "require-dev": {
+        "coenjacobs/mozart": "^0.7.1",
+        "eighteen73/settings-api": "^1.1"
+    },
+    "scripts": {
+		"post-install-cmd": [
+			"\"./vendor/bin/mozart\" compose"
+		],
+		"post-update-cmd": [
+			"\"./vendor/bin/mozart\" compose"
+		]
+    },
+	"extra": {
+		"mozart": {
+			"dep_namespace": "Eighteen73\\Orbit\\Vendor\\",
+			"dep_directory": "/packages/",
+			"packages": [
+				"eighteen73/settings-api"
+			],
+			"excluded_packages": [
+			],
+			"classmap_directory": "/classes/",
+			"classmap_prefix": "Eighteen73_Orbit_Vendor_",
+			"delete_vendor_directories": true
+		} 
+	}
+}

--- a/lib/composer.lock
+++ b/lib/composer.lock
@@ -1,0 +1,1205 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "bca4705421c2d09160f0211f7a3dd619",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "coenjacobs/mozart",
+            "version": "0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/coenjacobs/mozart.git",
+                "reference": "dbcdeb992d20d9c8914eef090f9a0d684bb1102c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/dbcdeb992d20d9c8914eef090f9a0d684bb1102c",
+                "reference": "dbcdeb992d20d9c8914eef090f9a0d684bb1102c",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^1.0",
+                "php": "^7.3|^8.0",
+                "symfony/console": "^4|^5",
+                "symfony/finder": "^4|^5"
+            },
+            "require-dev": {
+                "mheap/phpunit-github-actions-printer": "^1.4",
+                "phpunit/phpunit": "^8.5",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.4"
+            },
+            "bin": [
+                "bin/mozart"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CoenJacobs\\Mozart\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Coen Jacobs",
+                    "email": "coenjacobs@gmail.com"
+                }
+            ],
+            "description": "Composes all dependencies as a package inside a WordPress plugin",
+            "support": {
+                "issues": "https://github.com/coenjacobs/mozart/issues",
+                "source": "https://github.com/coenjacobs/mozart/tree/0.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/coenjacobs",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-02T21:37:03+00:00"
+        },
+        {
+            "name": "eighteen73/settings-api",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eighteen73/settings-api.git",
+                "reference": "26408fa101f7cc9e445936778681406ca74c58b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eighteen73/settings-api/zipball/26408fa101f7cc9e445936778681406ca74c58b7",
+                "reference": "26408fa101f7cc9e445936778681406ca74c58b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "eighteen73/phpcs-composer": "^1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eighteen73\\SettingsApi\\": "includes/classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A helper class for registering WordPress settings pages with a simpler API.",
+            "support": {
+                "issues": "https://github.com/eighteen73/settings-api/issues",
+                "source": "https://github.com/eighteen73/settings-api/tree/v1.1.2"
+            },
+            "time": "2022-12-12T17:51:29+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.1.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3239285c825c152bcc315fe0e87d6b55f5972ed1",
+                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/mime-type-detection": "^1.3",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/prophecy": "^1.11.1",
+                "phpunit/phpunit": "^8.5.8"
+            },
+            "suggest": {
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.10"
+            },
+            "funding": [
+                {
+                    "url": "https://offset.earth/frankdejonge",
+                    "type": "other"
+                }
+            ],
+            "time": "2022-10-04T09:16:37+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/a6dfb1194a2946fcdc1f38219445234f65b35c96",
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-05T12:09:49+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.4.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.4.28"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-07T06:12:30+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:55:41+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.4.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ff4bce3c33451e7ec778070e45bd23f74214cd5d",
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.4.27"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-31T08:02:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-28T09:04:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-30T19:17:58+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v6.0.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.0"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v6.0.19"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:36:10+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/lib/packages/Eighteen73/SettingsApi/SettingsApi.php
+++ b/lib/packages/Eighteen73/SettingsApi/SettingsApi.php
@@ -1,0 +1,959 @@
+<?php
+/**
+ * Main Class file for creating a settings page.
+ *
+ * @package Eighteen73
+ */
+
+namespace Eighteen73\Orbit\Vendor\Eighteen73\SettingsApi;
+
+/**
+ * Main Class file for creating a settings page.
+ */
+class SettingsApi {
+
+	/**
+	 * Page title for the settings page.
+	 *
+	 * @var string
+	 */
+	private $page_title;
+
+	/**
+	 * Menu title for the settings page.
+	 *
+	 * @var string
+	 */
+	private $menu_title;
+
+	/**
+	 * Capability for the settings page.
+	 *
+	 * @var string
+	 */
+	private $capability;
+
+	/**
+	 * Slug for the settings page.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Menu position for the settings page.
+	 *
+	 * @var int|null
+	 */
+	private $position;
+
+	/**
+	 * Sections array.
+	 *
+	 * @var array
+	 */
+	private $sections_array = [];
+
+	/**
+	 * Fields array.
+	 *
+	 * @var array
+	 */
+	private $fields_array = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $page_title Page title for the settings page.
+	 * @param string $menu_title Menu title for the settings page.
+	 * @param string $capability Capability for the settings page.
+	 * @param string $slug Slug for the settings page.
+	 * @param int|null $position Menu position for the settings page.
+	 */
+	public function __construct( $page_title, $menu_title, $capability, $slug, $position = null ) {
+
+		// Set variables.
+		$this->page_title = $page_title;
+		$this->menu_title = $menu_title;
+		$this->capability = $capability;
+		$this->slug       = $slug;
+		$this->position   = $position;
+
+		// Enqueue the admin scripts.
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
+
+		// Hook it up.
+		add_action( 'admin_init', [ $this, 'admin_init' ] );
+
+		// Menu.
+		add_action( 'admin_menu', [ $this, 'admin_menu' ] );
+	}
+
+	/**
+	 * Admin Scripts.
+	 *
+	 * @return void
+	 */
+	public function admin_scripts() {
+		// jQuery is needed.
+		wp_enqueue_script( 'jquery' );
+
+		// Color Picker.
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+		wp_enqueue_script(
+			'iris',
+			admin_url( 'js/iris.min.js' ),
+			[ 'jquery-ui-draggable', 'jquery-ui-slider', 'jquery-touch-punch' ],
+			false,
+			true,
+		);
+
+		// Media Uploader.
+		wp_enqueue_media();
+	}
+
+	/**
+	 * Set Sections.
+	 *
+	 * @param array $sections The settings page sections.
+	 */
+	public function set_sections( $sections ) {
+		// Bail if not array.
+		if ( ! is_array( $sections ) ) {
+			return false;
+		}
+
+		// Assign to the sections array.
+		$this->sections_array = $sections;
+
+		return $this;
+	}
+
+	/**
+	 * Add a single section.
+	 *
+	 * @param array $section The settings page sections.
+	 */
+	public function add_section( $section ) {
+		// Bail if not array.
+		if ( ! is_array( $section ) ) {
+			return false;
+		}
+
+		// Assign the section to sections array.
+		$this->sections_array[] = $section;
+
+		return $this;
+	}
+
+	/**
+	 * Set Fields.
+	 *
+	 * @param array $fields The settings page fields.
+	 */
+	public function set_fields( $fields ) {
+		// Bail if not array.
+		if ( ! is_array( $fields ) ) {
+			return false;
+		}
+
+		// Assign the fields.
+		$this->fields_array = $fields;
+
+		return $this;
+	}
+
+	/**
+	 * Add a single field.
+	 *
+	 * @param string $section The settings page section to add the field to.
+	 * @param array  $field_array Options to pass for the field.
+	 */
+	public function add_field( $section, $field_array ) {
+		// Set the defaults
+		$defaults = [
+			'id'   => '',
+			'name' => '',
+			'desc' => '',
+			'type' => 'text',
+		];
+
+		// Combine the defaults with user's arguements.
+		$arg = wp_parse_args( $field_array, $defaults );
+
+		// Each field is an array named against its section.
+		$this->fields_array[ $section ][] = $arg;
+
+		return $this;
+	}
+
+	/**
+	 * Initialize API.
+	 *
+	 * Initializes and registers the settings sections and fields.
+	 * Usually this should be called at `admin_init` hook.
+	 */
+	public function admin_init() {
+		/**
+		 * Register the sections.
+		 *
+		 * Sections array is like this:
+		 *
+		 * $sections_array = [
+		 *   $section_array,
+		 *   $section_array,
+		 *   $section_array,
+		 * ];
+		 *
+		 * Section array is like this:
+		 *
+		 * $section_array = [
+		 *   'id'    => 'section_id',
+		 *   'title' => 'Section Title'
+		 * ];
+		 */
+		foreach ( $this->sections_array as $section ) {
+			if ( false === get_option( $section['id'] ) ) {
+				// Add a new field as section ID.
+				add_option( $section['id'] );
+			}
+
+			// Deals with sections description.
+			if ( isset( $section['desc'] ) && ! empty( $section['desc'] ) ) {
+				// Build HTML.
+				$section['desc'] = '<div class="inside">' . $section['desc'] . '</div>';
+
+				// Create the callback for description.
+				$callback = function() use ( $section ) {
+					echo str_replace( '"', '\"', $section['desc'] );
+				};
+
+			} elseif ( isset( $section['callback'] ) ) {
+				$callback = $section['callback'];
+			} else {
+				$callback = null;
+			}
+
+			/**
+			 * Add a new section to a settings page.
+			 *
+			 * @param string $id
+			 * @param string $title
+			 * @param callable $callback
+			 * @param string $page | Page is same as section ID.
+			 */
+			add_settings_section( $section['id'], $section['title'], $callback, $section['id'] );
+		} // foreach ended.
+
+		/**
+		 * Register settings fields.
+		 *
+		 * Fields array is like this:
+		 *
+		 * $fields_array = [
+		 *   $section => $field_array,
+		 *   $section => $field_array,
+		 *   $section => $field_array,
+		 * ];
+		 *
+		 *
+		 * Field array is like this:
+		 *
+		 * $field_array = [
+		 *   'id'   => 'id',
+		 *   'name' => 'Name',
+		 *   'type' => 'text',
+		 * ];
+		 */
+		foreach ( $this->fields_array as $section => $field_array ) {
+			foreach ( $field_array as $field ) {
+				// ID.
+				$id = isset( $field['id'] ) ? $field['id'] : false;
+
+				// Type.
+				$type = isset( $field['type'] ) ? $field['type'] : 'text';
+
+				// Name.
+				$name = isset( $field['name'] ) ? $field['name'] : 'No Name Added';
+
+				// Label for.
+				$label_for = "{$section}[{$field['id']}]";
+
+				// Description.
+				$description = isset( $field['desc'] ) ? $field['desc'] : '';
+
+				// Size.
+				$size = isset( $field['size'] ) ? $field['size'] : null;
+
+				// Options.
+				$options = isset( $field['options'] ) ? $field['options'] : '';
+
+				// Standard default value.
+				$default = isset( $field['default'] ) ? $field['default'] : '';
+
+				// Standard default placeholder.
+				$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+
+				// Sanitize Callback.
+				$sanitize_callback = isset( $field['sanitize_callback'] ) ? $field['sanitize_callback'] : '';
+
+				$args = [
+					'id'                => $id,
+					'type'              => $type,
+					'name'              => $name,
+					'label_for'         => $label_for,
+					'desc'              => $description,
+					'section'           => $section,
+					'size'              => $size,
+					'options'           => $options,
+					'std'               => $default,
+					'placeholder'       => $placeholder,
+					'sanitize_callback' => $sanitize_callback,
+				];
+
+				/**
+				 * Add a new field to a section of a settings page.
+				 *
+				 * @param string   $id
+				 * @param string   $title
+				 * @param callable $callback
+				 * @param string   $page
+				 * @param string   $section = 'default'
+				 * @param array    $args = [)
+				 */
+
+				// @param string 	$id
+				$field_id = $section . '[' . $field['id'] . ']';
+
+				add_settings_field(
+					$field_id,
+					$name,
+					[ $this, 'callback_' . $type ],
+					$section,
+					$section,
+					$args
+				);
+			} // foreach ended.
+		} // foreach ended.
+
+		// Creates our settings in the fields table.
+		foreach ( $this->sections_array as $section ) {
+			/**
+			 * Registers a setting and its sanitization callback.
+			 *
+			 * @param string $field_group   | A settings group name.
+			 * @param string $field_name    | The name of an option to sanitize and save.
+			 * @param callable  $sanitize_callback = ''
+			 */
+			register_setting( $section['id'], $section['id'], [ $this, 'sanitize_fields' ] );
+		} // foreach ended.
+
+	} // admin_init() ended.
+
+	/**
+	 * Sanitize callback for Settings API fields.
+	 *
+	 * @param array $fields The fields array to sanitize.
+	 *
+	 * @return array
+	 */
+	public function sanitize_fields( $fields ) {
+		foreach ( $fields as $field_slug => $field_value ) {
+			$sanitize_callback = $this->get_sanitize_callback( $field_slug );
+
+			// If callback is set, call it.
+			if ( $sanitize_callback ) {
+				$fields[ $field_slug ] = call_user_func( $sanitize_callback, $field_value );
+				continue;
+			}
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Get sanitization callback for given option slug
+	 *
+	 * @param string $slug option slug.
+	 * @return mixed string | bool false
+	 */
+	public function get_sanitize_callback( $slug = '' ) {
+		if ( empty( $slug ) ) {
+			return false;
+		}
+
+		// Iterate over registered fields and see if we can find proper callback.
+		foreach ( $this->fields_array as $section => $field_array ) {
+			foreach ( $field_array as $field ) {
+				if ( $field['name'] !== $slug ) {
+					continue;
+				}
+
+				// Return the callback name.
+				return isset( $field['sanitize_callback'] ) && is_callable( $field['sanitize_callback'] ) ? $field['sanitize_callback'] : false;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get field description for display
+	 *
+	 * @param array $args settings field args
+	 *
+	 * @return string
+	 */
+	public function get_field_description( $args ) {
+		if ( ! empty( $args['desc'] ) ) {
+			$desc = sprintf(
+				'<p class="description">%s</p>',
+				is_callable( $args['desc'] )
+					? call_user_func( $args['desc'] )
+					: $args['desc']
+			);
+		} else {
+			$desc = '';
+		}
+
+		return $desc;
+	}
+
+	/**
+	 * Displays a title field for a settings field
+	 *
+	 * @param array $args settings field args
+	 *
+	 * @return void
+	 */
+	public function callback_title( $args ) {
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		if ( '' !== $args['name'] ) {
+			$name = $args['name'];
+		}
+		$type = isset( $args['type'] ) ? $args['type'] : 'title';
+
+		$html = '';
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a text field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_text( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'], $args['placeholder'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+		$type  = isset( $args['type'] ) ? $args['type'] : 'text';
+
+		$html  = sprintf( '<input type="%1$s" class="%2$s-text" id="%3$s[%4$s]" name="%3$s[%4$s]" value="%5$s"placeholder="%6$s"/>', $type, $size, $args['section'], $args['id'], $value, $args['placeholder'] );
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a url field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_url( $args ) {
+		$this->callback_text( $args );
+	}
+
+	/**
+	 * Displays an email field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_email( $args ) {
+		$this->callback_text( $args );
+	}
+
+	/**
+	 * Displays a number field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_number( $args ) {
+		$this->callback_text( $args );
+	}
+
+	/**
+	 * Displays a checkbox for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_checkbox( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+
+		$html  = '<fieldset>';
+		$html .= sprintf( '<label for="' . $this->slug . '%1$s[%2$s]">', $args['section'], $args['id'] );
+		$html .= sprintf( '<input type="hidden" name="%1$s[%2$s]" value="off" />', $args['section'], $args['id'] );
+		$html .= sprintf( '<input type="checkbox" class="checkbox" id="' . $this->slug . '-%1$s[%2$s]" name="%1$s[%2$s]" value="on" %3$s />', $args['section'], $args['id'], checked( $value, 'on', false ) );
+		$html .= sprintf( '%1$s</label>', $args['desc'] );
+		$html .= '</fieldset>';
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a multicheckbox a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_multicheck( $args ) {
+
+		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
+
+		$html = '<fieldset>';
+		foreach ( $args['options'] as $key => $item ) {
+			$value   = $this->get_option( $args['id'], $args['section'], $args['std'] );
+			$label   = is_array( $item ) ? $item['label'] : $item;
+			$checked = isset( $value[ $key ] ) ? $value[ $key ] : '0';
+
+			$html   .= sprintf( '<label for="' . $this->slug . '-%1$s[%2$s][%3$s]">', $args['section'], $args['id'], $key );
+			$html   .= sprintf( '<input type="checkbox" class="checkbox" id="' . $this->slug . '-%1$s[%2$s][%3$s]" name="%1$s[%2$s][%3$s]" value="%3$s" %4$s />', $args['section'], $args['id'], $key, checked( $checked, $key, false ) );
+			$html   .= sprintf( '%1$s</label><br>', $label );
+			$html   .= $this->get_field_description( $item );
+		}
+		$html .= $this->get_field_description( $args );
+		$html .= '</fieldset>';
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a multicheckbox a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_radio( $args ) {
+
+		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
+
+		$html = '<fieldset>';
+		foreach ( $args['options'] as $key => $label ) {
+			$html .= sprintf( '<label for="' . $this->slug . '-%1$s[%2$s][%3$s]">', $args['section'], $args['id'], $key );
+			$html .= sprintf( '<input type="radio" class="radio" id="' . $this->slug . '-%1$s[%2$s][%3$s]" name="%1$s[%2$s]" value="%3$s" %4$s />', $args['section'], $args['id'], $key, checked( $value, $key, false ) );
+			$html .= sprintf( '%1$s</label><br>', $label );
+		}
+		$html .= $this->get_field_description( $args );
+		$html .= '</fieldset>';
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a selectbox for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_select( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+
+		$html = sprintf( '<select class="%1$s" name="%2$s[%3$s]" id="%2$s[%3$s]">', $size, $args['section'], $args['id'] );
+		foreach ( $args['options'] as $key => $label ) {
+			$html .= sprintf( '<option value="%s"%s>%s</option>', $key, selected( $value, $key, false ), $label );
+		}
+		$html .= sprintf( '</select>' );
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a textarea for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_textarea( $args ) {
+
+		$value = esc_textarea( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+
+		$html  = sprintf( '<textarea rows="5" cols="55" class="%1$s-text" id="%2$s[%3$s]" name="%2$s[%3$s]">%4$s</textarea>', $size, $args['section'], $args['id'], $value );
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a textarea for a settings field
+	 *
+	 * @param array $args settings field args.
+	 *
+	 * @return void
+	 */
+	public function callback_html( $args ) {
+		echo $this->get_field_description( $args );
+	}
+
+	/**
+	 * Displays a rich text textarea for a settings field
+	 *
+	 * @param array $args settings field args.
+	 */
+	public function callback_wysiwyg( $args ) {
+
+		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : '500px';
+
+		echo '<div style="max-width: ' . esc_attr( $size ) . ';">';
+
+		$editor_settings = [
+			'teeny'         => true,
+			'textarea_name' => $args['section'] . '[' . $args['id'] . ']',
+			'textarea_rows' => 10,
+		];
+		if ( isset( $args['options'] ) && is_array( $args['options'] ) ) {
+			$editor_settings = array_merge( $editor_settings, $args['options'] );
+		}
+
+		wp_editor( $value, $args['section'] . '-' . $args['id'], $editor_settings );
+
+		echo '</div>';
+
+		echo $this->get_field_description( $args );
+	}
+
+	/**
+	 * Displays a file upload field for a settings field
+	 *
+	 * @param array $args settings field args.
+	 */
+	public function callback_file( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+		$id    = $args['section'] . '[' . $args['id'] . ']';
+		$label = isset( $args['options']['button_label'] ) ?
+		$args['options']['button_label'] :
+		__( 'Choose File' );
+
+		$html  = sprintf( '<input type="text" class="%1$s-text eighteen73-url" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s"/>', $size, $args['section'], $args['id'], $value );
+		$html .= '<input type="button" class="button eighteen73-browse" value="' . $label . '" />';
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays an image upload field with a preview
+	 *
+	 * @param array $args settings field args.
+	 */
+	public function callback_image( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+		$id    = $args['section'] . '[' . $args['id'] . ']';
+		$label = isset( $args['options']['button_label'] ) ?
+		$args['options']['button_label'] :
+		__( 'Choose Image' );
+
+		$html  = sprintf( '<input type="text" class="%1$s-text eighteen73-url" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s"/>', $size, $args['section'], $args['id'], $value );
+		$html .= '<input type="button" class="button eighteen73-browse" value="' . $label . '" />';
+		$html .= $this->get_field_description( $args );
+		$html .= '<p class="eighteen73-image-preview"><img src=""/></p>';
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a password field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_password( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+
+		$html  = sprintf( '<input type="password" class="%1$s-text" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s"/>', $size, $args['section'], $args['id'], $value );
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a color picker field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_color( $args ) {
+
+		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'], $args['placeholder'] ) );
+		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
+
+		$html  = sprintf( '<input type="text" class="%1$s-text color-picker" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s" data-default-color="%5$s" placeholder="%6$s" />', $size, $args['section'], $args['id'], $value, $args['std'], $args['placeholder'] );
+		$html .= $this->get_field_description( $args );
+
+		echo $html;
+	}
+
+	/**
+	 * Displays a separator field for a settings field
+	 *
+	 * @param array $args settings field args
+	 */
+	public function callback_separator( $args ) {
+		$type = isset( $args['type'] ) ? $args['type'] : 'separator';
+
+		$html  = '';
+		$html .= '<div class="eighteen73-settings-separator"></div>';
+		echo $html;
+	}
+
+	/**
+	 * Get the value of a settings field
+	 *
+	 * @param string $option  settings field name.
+	 * @param string $section the section name this field belongs to.
+	 * @param string $default default text if it's not found.
+	 * @return string
+	 */
+	public function get_option( $option, $section, $default = '' ) {
+
+		$options = get_option( $section );
+
+		if ( isset( $options[ $option ] ) ) {
+			return $options[ $option ];
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Add submenu page to the Settings main menu.
+	 */
+	public function admin_menu() {
+		add_options_page(
+			$this->page_title,
+			$this->menu_title,
+			$this->capability,
+			$this->slug,
+			[ $this, 'plugin_page' ],
+			$this->position,
+		);
+	}
+
+	/**
+	 * Renders the settings page.
+	 *
+	 * @return void
+	 */
+	public function plugin_page() {
+		echo '<div class="wrap">';
+		echo '<h1>' . $this->page_title . '</h1>';
+		$this->show_navigation();
+		$this->show_forms();
+		echo '</div>';
+	}
+
+	/**
+	 * Show navigations as tab
+	 *
+	 * Shows all the settings section labels as tabs.
+	 *
+	 * @return void
+	 */
+	public function show_navigation() {
+		$html = '<h2 class="nav-tab-wrapper">';
+
+		foreach ( $this->sections_array as $tab ) {
+			$html .= sprintf( '<a href="#%1$s" class="nav-tab" id="%1$s-tab">%2$s</a>', $tab['id'], $tab['title'] );
+		}
+
+		$html .= '</h2>';
+
+		echo $html;
+	}
+
+	/**
+	 * Show the section settings forms.
+	 *
+	 * This function displays every sections in a different form.
+	 *
+	 * @return void
+	 */
+	public function show_forms() {
+		$default = [
+			'label_submit' => null,
+			'submit_type'  => 'primary',
+			'wrap'         => true,
+			'attributes'   => null,
+		];
+		?>
+
+		<div class="metabox-holder">
+			<?php foreach ( $this->sections_array as $form ) : ?>
+				<?php
+				$form = wp_parse_args( $form, $default );
+				?>
+				<!-- style="display: none;" -->
+				<div id="<?php echo esc_attr( $form['id'] ); ?>" class="group" >
+					<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+						<?php
+						do_action( 'eighteen73_form_top_' . $form['id'], $form );
+						settings_fields( $form['id'] );
+						do_settings_sections( $form['id'] );
+						do_action( 'eighteen73_form_bottom_' . $form['id'], $form );
+						submit_button( $form['label_submit'], $form['submit_type'], 'submit_' . $form['id'], $form['wrap'], $form['attributes'] );
+						?>
+					</form>
+				</div>
+			<?php endforeach; ?>
+		</div>
+		<?php
+		$this->script();
+	}
+
+	/**
+	 * Tabbable JavaScript codes & Initiate Color Picker.
+	 *
+	 * This code uses localstorage for displaying active tabs.
+	 *
+	 * @return void
+	 */
+	public function script() {
+		?>
+			<script>
+				jQuery( document ).ready( function( $ ) {
+
+				//Initiate Color Picker.
+				$('.color-picker').iris();
+
+				// Switches option sections
+				$( '.group' ).hide();
+				var activetab = '';
+				if ( 'undefined' !== typeof localStorage ) {
+					activetab = localStorage.getItem( 'activetab' );
+				}
+				if ( '' !== activetab && $( activetab ).length ) {
+					$( activetab ).show();
+				} else {
+					$( '.group:first' ).show();
+				}
+				$( '.group .collapsed' ).each( function() {
+					$( this )
+						.find( 'input:checked' )
+						.parent()
+						.parent()
+						.parent()
+						.nextAll()
+						.each( function() {
+							if ( $( this ).hasClass( 'last' ) ) {
+								$( this ).removeClass( 'hidden' );
+								return false;
+							}
+							$( this )
+								.filter( '.hidden' )
+								.removeClass( 'hidden' );
+						});
+				});
+
+				if ( '' !== activetab && $( activetab + '-tab' ).length ) {
+					$( activetab + '-tab' ).addClass( 'nav-tab-active' );
+				} else {
+					$( '.nav-tab-wrapper a:first' ).addClass( 'nav-tab-active' );
+				}
+				$( '.nav-tab-wrapper a' ).click( function( evt ) {
+					$( '.nav-tab-wrapper a' ).removeClass( 'nav-tab-active' );
+					$( this )
+						.addClass( 'nav-tab-active' )
+						.blur();
+					var clicked_group = $( this ).attr( 'href' );
+					if ( 'undefined' != typeof localStorage ) {
+						localStorage.setItem( 'activetab', $( this ).attr( 'href' ) );
+					}
+					$( '.group' ).hide();
+					$( clicked_group ).show();
+					evt.preventDefault();
+				});
+
+				$( '.eighteen73-browse' ).on( 'click', function( event ) {
+					event.preventDefault();
+
+					var self = $( this );
+
+					// Create the media frame.
+					var file_frame = ( wp.media.frames.file_frame = wp.media({
+						title: self.data( 'uploader_title' ),
+						button: {
+							text: self.data( 'uploader_button_text' )
+						},
+						multiple: false
+					}) );
+
+					file_frame.on( 'select', function() {
+						attachment = file_frame
+							.state()
+							.get( 'selection' )
+							.first()
+							.toJSON();
+
+						self
+							.prev( '.eighteen73-url' )
+							.val( attachment.url )
+							.change();
+					});
+
+					// Finally, open the modal
+					file_frame.open();
+				});
+
+				$( 'input.eighteen73-url' )
+					.on( 'change keyup paste input', function() {
+						var self = $( this );
+						self
+							.next()
+							.parent()
+							.children( '.eighteen73-image-preview' )
+							.children( 'img' )
+							.attr( 'src', self.val() );
+					})
+					.change();
+			});
+			</script>
+
+			<style type="text/css">
+				#wpbody-content .metabox-holder {
+					padding-top: 5px;
+				}
+
+				.eighteen73-image-preview img {
+					height: auto;
+					max-width: 70px;
+				}
+
+				.eighteen73-settings-separator {
+					background: #ccc;
+					border: 0;
+					color: #ccc;
+					height: 1px;
+					position: absolute;
+					left: 0;
+					width: 99%;
+				}
+
+				.group .form-table input.color-picker {
+					max-width: 100px;
+				}
+
+				/**
+				 * Space for multi checkbox and multi radio fields with their own descriptions.
+				 */
+				.group .form-table .description + label {
+					margin-top: 20px !important;
+				}
+			</style>
+		<?php
+	}
+}

--- a/orbit.php
+++ b/orbit.php
@@ -50,6 +50,7 @@ add_action(
 		Admin\HideUpdates::instance()->setup();
 		Security\DisableAPI::instance()->setup();
 		Security\DisableXMLRPC::instance()->setup();
+		Security\HideAuthor::instance()->setup();
 		Security\HideVersion::instance()->setup();
 		Security\RemoveHeadLinks::instance()->setup();
 		OtherFilters::instance()->setup();

--- a/orbit.php
+++ b/orbit.php
@@ -24,21 +24,7 @@ define( 'ORBIT_URL', plugin_dir_url( __FILE__ ) );
 define( 'ORBIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ORBIT_INC', ORBIT_PATH . 'includes/' );
 
-spl_autoload_register(
-	function ( $class_name ) {
-		$path_parts = explode( '\\', $class_name );
-
-		if ( ! empty( $path_parts ) ) {
-			$package = $path_parts[0];
-
-			unset( $path_parts[0] );
-
-			if ( 'Orbit' === $package ) {
-				require_once __DIR__ . '/includes/classes/' . implode( '/', $path_parts ) . '.php';
-			}
-		}
-	}
-);
+require_once 'autoload.php';
 
 Forms\Options::instance()->setup();
 DisallowIndexing\DisallowIndexing::instance()->setup();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<rule ref="Eighteen73-WordPress-Default" />
 	<file>.</file>
 	<exclude-pattern>dist/</exclude-pattern>
+	<exclude-pattern>lib/packages/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
This is a hard block on author pages. 

I don't think we've ever needed it on our websites so there are good security reasons to disable it. If we ever find them to be necessary for a project we can extend this functionality to be a configurable option.