### PR TITLE
Disable the /wp-json/wp/v2/users endpoint only when not admin

### DIFF
--- a/includes/classes/Security/DisableAPI.php
+++ b/includes/classes/Security/DisableAPI.php
@@ -35,11 +35,13 @@ class DisableAPI {
 	 * @return array
 	 */
 	public function disable_users( array $endpoints ): array {
-		if ( isset( $endpoints['/wp/v2/users'] ) ) {
-			unset( $endpoints['/wp/v2/users'] );
-		}
-		if ( isset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] ) ) {
-			unset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] );
+		if ( ! is_user_logged_in() && ! is_admin() ) {
+			if ( isset( $endpoints['/wp/v2/users'] ) ) {
+				unset( $endpoints['/wp/v2/users'] );
+			}
+			if ( isset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] ) ) {
+				unset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] );
+			}
 		}
 		return $endpoints;
 	}


### PR DESCRIPTION
wrapped statement unsetting the users endpoints in an if statement checking that its not in the admin and not a logged in user before disabling the endpoints