### PR TITLE
Use `ORBIT_URL` to fix HTTPS content warning

### DIFF
--- a/includes/classes/Admin/HideUpdates.php
+++ b/includes/classes/Admin/HideUpdates.php
@@ -125,6 +125,6 @@ class HideUpdates {
 	 * @return void
 	 */
 	public function enqueue_plugin_styles(): void {
-		wp_enqueue_style( 'hide_updates_css', WPMU_PLUGIN_URL . '/orbit/css/hide-updates.css' );
+		wp_enqueue_style( 'hide_updates_css', ORBIT_URL . 'css/hide-updates.css' );
 	}
 }


### PR DESCRIPTION
Using `WPMU_PLUGIN_URL` loads the CSS file over HTTP, which results in a mixed content warning.

![CleanShot 2024-06-10 at 12 52 43](https://github.com/eighteen73/orbit/assets/92863/0b02ad7e-3274-4bf5-8875-d3863acd9025)

Changing this to `ORBIT_URL` resolves the issue.