### PR TITLE
Cache registered patterns

### DIFF
--- a/includes/classes/BlockEditor/Patterns.php
+++ b/includes/classes/BlockEditor/Patterns.php
@@ -36,7 +36,10 @@ class Patterns {
 	 * @return void
 	 */
 	public function remove_woocommerce_patterns(): void {
-		$patterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+		if ( false === ( $patterns = get_transient( 'orbit_registered_patterns' ) ) ) {
+			$patterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+			set_transient( 'orbit_registered_patterns', $patterns, 300 );
+		}
 
 		if ( ! empty( $patterns ) ) {
 			foreach ( $patterns as $pattern ) {


### PR DESCRIPTION
There is be a measurable saving to requests by caching the patterns.

Is it OK to do a 5 min cache on these? Presumably they don't change very frequently but it could be confusing to users when they are caught out by cached data.