### PR TITLE
Add random query param to Altcha challenge URLs to bypass caching

### DIFF
--- a/includes/classes/ThirdParty/Altcha.php
+++ b/includes/classes/ThirdParty/Altcha.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Modifications to Altcha.
+ *
+ * @package Orbit
+ */
+
+namespace Eighteen73\Orbit\ThirdParty;
+
+use Eighteen73\Orbit\Singleton;
+
+/**
+ * Modifications to Altcha.
+ */
+class Altcha {
+	use Singleton;
+
+	/**
+	 * Run on init
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		add_filter( 'altcha_challenge_url', [ $this, 'altcha_challenge_url' ] );
+	}
+
+	/**
+	 * Override the Altcha challenge URL
+	 * We want to ensure the url is never cached, so we add a query string to ensure it's always unique.
+	 *
+	 * @param string $url The Altcha challenge URL
+	 * @return string
+	 */
+	public function altcha_challenge_url( string $url ): string {
+		return $url . '?r=' . wp_rand( 1000, 9999 );
+	}
+}

--- a/orbit.php
+++ b/orbit.php
@@ -30,6 +30,7 @@ require_once 'autoload.php';
 DisallowIndexing\DisallowIndexing::instance()->setup();
 Performance\Fast404::instance()->setup();
 ThirdParty\WooCommerce::instance()->setup();
+ThirdParty\Altcha::instance()->setup();
 
 add_action(
 	'init',


### PR DESCRIPTION
As discussed, on Kinsta and other heavy caching hosts, the api endpoint gets cached.
This should hopefully bypass that issue.