### PR TITLE
Override WordPress' default error_reporting verbosity

### DIFF
--- a/includes/classes/Plugin.php
+++ b/includes/classes/Plugin.php
@@ -45,5 +45,6 @@ class Plugin {
 		ThirdParty\WooCommerce::instance()->setup();
 		ThirdParty\Altcha::instance()->setup();
 		ThirdParty\ActionScheduler::instance()->setup();
+		Utilities\ErrorReporting::instance()->setup();
 	}
 }

--- a/includes/classes/Utilities/ErrorReporting.php
+++ b/includes/classes/Utilities/ErrorReporting.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Overrides WordPress' default error_reporting because that's too verbose for non-development environments.
+ *
+ * @package         Orbit
+ */
+
+namespace Eighteen73\Orbit\Utilities;
+
+use Eighteen73\Orbit\Environment;
+use Eighteen73\Orbit\Singleton;
+
+/**
+ * Overrides WordPress' default error_reporting
+ */
+class ErrorReporting {
+
+	use Environment;
+	use Singleton;
+
+	/**
+	 * Setup module
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+
+		if ( defined( 'ORBIT_ERROR_REPORTING' ) && ORBIT_ERROR_REPORTING === false ) {
+			return;
+		}
+
+		add_action( 'muplugins_loaded', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Initialising is done early enough that other plugins can override it when needed.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		if ( defined( 'ORBIT_ERROR_REPORTING' ) ) {
+			$error_level = ORBIT_ERROR_REPORTING;
+		} else {
+			$error_level = E_ERROR
+						   + E_WARNING
+						   + E_NOTICE
+						   + E_PARSE
+						   + E_DEPRECATED
+						   + E_CORE_ERROR
+						   + E_CORE_WARNING
+						   + E_COMPILE_ERROR
+						   + E_USER_ERROR
+						   + E_USER_WARNING
+						   + E_USER_NOTICE
+						   + E_RECOVERABLE_ERROR;
+			if ( $this->environment() !== 'development' ) {
+				$error_level = $error_level & ~E_NOTICE & ~E_USER_NOTICE & ~E_WARNING & ~E_USER_WARNING & ~E_DEPRECATED;
+			}
+		}
+
+		error_reporting( $error_level );
+	}
+}

--- a/includes/classes/Utilities/ErrorReporting.php
+++ b/includes/classes/Utilities/ErrorReporting.php
@@ -38,8 +38,8 @@ class ErrorReporting {
 	 * @return void
 	 */
 	public function init(): void {
-		if ( defined( 'ORBIT_ERROR_REPORTING' ) ) {
-			$error_level = ORBIT_ERROR_REPORTING;
+		if ( defined( 'ORBIT_ERROR_REPORTING' ) && ! empty( ORBIT_ERROR_REPORTING ) ) {
+			$error_level = (int) ORBIT_ERROR_REPORTING;
 		} else {
 			$error_level = E_ERROR
 						   + E_WARNING


### PR DESCRIPTION
Production error logs are often too verbose, with lots of PHP notices and warning from 3rd party code that's outside of our control. Even notices and warning that _are_ in our control don't need to be logged in production and they obfusatice more important errors.

With this PR, Orbit overrides the `error_reporting()` value as soon as the `muplugins_loaded` action is called. It applies a sensible default verbosity but extends it in development environments by adding notices, warnings and deprecation messages. 

Websites can override Orbit's new defaults in their own config files using:

```php
// Set a custom value
Config::define( 'ORBIT_ERROR_REPORTING', E_ALL );

// Disable Orbit's handler entirely (i.e. revert to WordPress defaults)
Config::define( 'ORBIT_ERROR_REPORTING', false );
```

This PR does not touch the overall debug display/logging options, it only configures _what_ gets logged when they are active.