### PR TITLE
Add blob: to script-src CSP

### DIFF
--- a/includes/classes/Security/Headers.php
+++ b/includes/classes/Security/Headers.php
@@ -50,7 +50,7 @@ class Headers {
 				[
 					"default-src 'self' https:",
 					"img-src 'self' https: data: blob:",
-					"script-src 'self' https: 'unsafe-inline' 'unsafe-eval'",
+					"script-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'",
 					"style-src 'self' https: 'unsafe-inline'",
 					"font-src 'self' https: data:",
 					"worker-src 'self' https: blob:",


### PR DESCRIPTION
Not ideal but it seems to be a necessary default for 3rd party integrations. The onus is on individual websites to use our `orbit_default_security_headers` filter to tighten the CSP where possible.